### PR TITLE
feat: Add Feed, Feed V2 tabs, and categories to profile section

### DIFF
--- a/components/leaderboard/LeaderboardRow.tsx
+++ b/components/leaderboard/LeaderboardRow.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
+import { getCategoryIcon, getCategoryColor, type Category } from "@/lib/categories";
 
 interface LeaderboardRowProps {
   rank: number;
@@ -9,6 +10,7 @@ interface LeaderboardRowProps {
   score: number;
   rewards: string; // e.g., "0.08 ETH"
   highlight?: boolean;
+  category?: Category | null;
 }
 
 export const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
@@ -18,6 +20,7 @@ export const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
   score,
   rewards,
   highlight = false,
+  category,
 }) => {
   return (
     <div
@@ -44,9 +47,17 @@ export const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
           <span className="font-semibold truncate leading-tight text-base">
             {name}
           </span>
-          <span className="text-xs text-muted-foreground">
-            Creator Score: {score}
-          </span>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>Creator Score: {score}</span>
+            {category && (
+              <>
+                <span>•</span>
+                <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs ${getCategoryColor(category)} text-white`}>
+                  {getCategoryIcon(category)} {category}
+                </span>
+              </>
+            )}
+          </div>
         </div>
       </div>
       {/* Rewards */}

--- a/components/profile/CategoryBreakdownModal.tsx
+++ b/components/profile/CategoryBreakdownModal.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import * as React from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { 
+  CategoryBreakdown, 
+  getCategoryColor, 
+  getCategorySvgColor,
+  getCategoryBgColor,
+  getCategoryIcon,
+  type Category 
+} from "@/lib/categories";
+
+interface CategoryBreakdownModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  breakdown: CategoryBreakdown[];
+  issuerBreakdown: Array<{
+    issuer: string;
+    category: Category | null;
+    points: number;
+    percentage: number;
+    credentials: Array<{
+      issuer: string;
+      label: string;
+      points: number;
+    }>;
+  }>;
+  totalPoints: number;
+  primaryCategory: Category | null;
+}
+
+export function CategoryBreakdownModal({
+  open,
+  onOpenChange,
+  breakdown,
+  issuerBreakdown,
+  totalPoints,
+  primaryCategory,
+}: CategoryBreakdownModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span>Creator Categories</span>
+            {primaryCategory && (
+              <Badge 
+                className={`${getCategoryColor(primaryCategory)} text-white`}
+              >
+                {getCategoryIcon(primaryCategory)} {primaryCategory}
+              </Badge>
+            )}
+          </DialogTitle>
+        </DialogHeader>
+        
+        <div className="space-y-4">
+          {/* Platform List */}
+          <div className="space-y-4">
+            {issuerBreakdown.map((item) => (
+              <div key={item.issuer} className={`rounded-lg border p-4 ${item.category ? getCategoryBgColor(item.category) : 'bg-gray-50 border-gray-200'}`}>
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-3">
+                    <div className={`w-10 h-10 rounded-full ${item.category ? getCategoryColor(item.category) : 'bg-gray-500'} flex items-center justify-center text-white text-lg`}>
+                      {item.category ? getCategoryIcon(item.category) : "📊"}
+                    </div>
+                    <div>
+                      <h3 className="font-semibold text-base">{item.issuer}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {item.category ? item.category : 'Uncategorized'} • {item.credentials.length} credential{item.credentials.length !== 1 ? 's' : ''}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-lg font-bold">{item.points.toLocaleString()}</div>
+                    <div className="text-xs text-muted-foreground">points</div>
+                  </div>
+                </div>
+                
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Contribution</span>
+                    <span className="font-medium">{item.percentage.toFixed(1)}%</span>
+                  </div>
+                  <Progress 
+                    value={item.percentage} 
+                    className="h-2"
+                    style={{
+                      '--progress-color': item.category ? getCategorySvgColor(item.category) : '#9ca3af'
+                    } as React.CSSProperties}
+                  />
+                </div>
+                
+                {/* Credentials breakdown */}
+                <div className="mt-3 space-y-2">
+                  <h4 className="text-sm font-medium text-muted-foreground">Credentials</h4>
+                  <div className="space-y-1">
+                    {item.credentials.length > 0 ? (
+                      item.credentials.map((credential, idx) => (
+                        <div key={idx} className="flex items-center justify-between text-xs">
+                          <span className="truncate text-muted-foreground">{credential.label}</span>
+                          <span className="font-medium">{credential.points.toLocaleString()}</span>
+                        </div>
+                      ))
+                    ) : (
+                      <div className="text-xs text-muted-foreground italic">
+                        Coming soon...
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+} 

--- a/components/profile/FeedGrid.tsx
+++ b/components/profile/FeedGrid.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ExternalLink, TrendingUp, Heart, Repeat, Users, Calendar } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FeedPost {
+  platform: "zora" | "farcaster" | "lens" | "paragraph" | "twitter" | "pods";
+  title?: string;
+  content?: string;
+  revenue?: string;
+  collectors?: number;
+  retweets?: number;
+  likes?: number;
+  date: string;
+  url?: string;
+}
+
+interface FeedGridProps {
+  posts?: FeedPost[];
+}
+
+const platformConfig = {
+  zora: {
+    name: "Zora",
+    color: "bg-purple-100 text-purple-700 border-purple-200",
+    icon: "🎨",
+  },
+  farcaster: {
+    name: "Farcaster",
+    color: "bg-blue-100 text-blue-700 border-blue-200",
+    icon: "🟣",
+  },
+  lens: {
+    name: "Lens",
+    color: "bg-green-100 text-green-700 border-green-200",
+    icon: "🌿",
+  },
+  paragraph: {
+    name: "Paragraph",
+    color: "bg-orange-100 text-orange-700 border-orange-200",
+    icon: "📝",
+  },
+  twitter: {
+    name: "Twitter",
+    color: "bg-sky-100 text-sky-700 border-sky-200",
+    icon: "🐦",
+  },
+  pods: {
+    name: "Pods",
+    color: "bg-indigo-100 text-indigo-700 border-indigo-200",
+    icon: "🎧",
+  },
+};
+
+export function FeedGrid({ posts = [] }: FeedGridProps) {
+  // Mock data for demonstration - in real app this would come from API
+  const mockPosts: FeedPost[] = [
+    {
+      platform: "zora",
+      title: "Digital Art Collection #1",
+      revenue: "2.5 ETH",
+      collectors: 45,
+      date: "2024-01-15",
+      url: "https://zora.co/collection/123",
+    },
+    {
+      platform: "farcaster",
+      content: "Just launched my new creator score app! 🚀",
+      retweets: 23,
+      likes: 156,
+      date: "2024-01-20",
+      url: "https://warpcast.com/~/cast/123",
+    },
+    {
+      platform: "lens",
+      content: "Building the future of social media...",
+      retweets: 12,
+      likes: 89,
+      date: "2024-01-18",
+      url: "https://lens.xyz/posts/123",
+    },
+    {
+      platform: "paragraph",
+      title: "The Future of Creator Economy",
+      revenue: "0.8 ETH",
+      collectors: 23,
+      date: "2024-01-22",
+      url: "https://paragraph.xyz/article/123",
+    },
+    {
+      platform: "twitter",
+      content: "Excited to share my latest project with everyone! 🚀",
+      retweets: 45,
+      likes: 234,
+      date: "2024-01-19",
+      url: "https://twitter.com/user/status/123",
+    },
+    {
+      platform: "pods",
+      title: "Creator Economy Podcast #15",
+      revenue: "1.2 ETH",
+      collectors: 67,
+      date: "2024-01-21",
+      url: "https://pods.xyz/podcast/123",
+    },
+  ];
+
+  const displayPosts = posts.length > 0 ? posts : mockPosts;
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", { 
+      month: "short", 
+      day: "numeric",
+      year: "numeric"
+    });
+  };
+
+  const truncateText = (text: string, maxLength: number = 20) => {
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + "...";
+  };
+
+  const handlePostClick = async (url?: string) => {
+    if (!url) return;
+    
+    try {
+      // Try to open in Farcaster frame if available
+      if (typeof window !== "undefined" && (window as any).farcaster) {
+        await (window as any).farcaster.openUrl(url);
+      } else {
+        window.open(url, "_blank", "noopener,noreferrer");
+      }
+    } catch {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {displayPosts.map((post, index) => {
+        const config = platformConfig[post.platform];
+        
+        return (
+          <Card 
+            key={index} 
+            className={cn(
+              "cursor-pointer transition-all duration-200 hover:shadow-md hover:scale-[1.02]",
+              "border-2 hover:border-primary/20"
+            )}
+            onClick={() => handlePostClick(post.url)}
+          >
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-lg">{config.icon}</span>
+                  <CardTitle className="text-sm font-semibold">
+                    {config.name}
+                  </CardTitle>
+                </div>
+                {post.url && (
+                  <ExternalLink className="w-3 h-3 text-muted-foreground" />
+                )}
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0 space-y-3">
+              {/* Content */}
+              <div className="space-y-2">
+                {post.title && (
+                  <h4 className="font-medium text-sm leading-tight">
+                    {truncateText(post.title, 25)}
+                  </h4>
+                )}
+                {post.content && (
+                  <p className="text-xs text-muted-foreground leading-tight">
+                    {truncateText(post.content, 30)}
+                  </p>
+                )}
+              </div>
+
+              {/* Stats */}
+              <div className="space-y-2">
+                {post.revenue && (
+                  <div className="flex items-center gap-1 text-xs">
+                    <TrendingUp className="w-3 h-3 text-green-600" />
+                    <span className="font-medium text-green-600">{post.revenue}</span>
+                  </div>
+                )}
+                
+                {post.collectors && (
+                  <div className="flex items-center gap-1 text-xs">
+                    <Users className="w-3 h-3 text-blue-600" />
+                    <span className="text-muted-foreground">{post.collectors} collectors</span>
+                  </div>
+                )}
+                
+                {(post.retweets || post.likes) && (
+                  <div className="flex items-center gap-3 text-xs">
+                    {post.retweets && (
+                      <div className="flex items-center gap-1">
+                        <Repeat className="w-3 h-3 text-blue-500" />
+                        <span className="text-muted-foreground">{post.retweets}</span>
+                      </div>
+                    )}
+                    {post.likes && (
+                      <div className="flex items-center gap-1">
+                        <Heart className="w-3 h-3 text-red-500" />
+                        <span className="text-muted-foreground">{post.likes}</span>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* Date */}
+              <div className="flex items-center gap-1 text-xs text-muted-foreground pt-1 border-t">
+                <Calendar className="w-3 h-3" />
+                <span>{formatDate(post.date)}</span>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+} 

--- a/components/profile/FeedGridV2.tsx
+++ b/components/profile/FeedGridV2.tsx
@@ -1,0 +1,268 @@
+import React from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ExternalLink, TrendingUp, Heart, Repeat, Users, Calendar, Image } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FeedPostV2 {
+  platform: "zora" | "farcaster" | "lens" | "paragraph" | "twitter" | "pods";
+  title?: string;
+  content?: string;
+  revenue?: string;
+  collectors?: number;
+  retweets?: number;
+  likes?: number;
+  date: string;
+  url?: string;
+  imageUrl?: string;
+  imageAlt?: string;
+}
+
+interface FeedGridV2Props {
+  posts?: FeedPostV2[];
+}
+
+const platformConfig = {
+  zora: {
+    name: "Zora",
+    color: "bg-purple-100 text-purple-700 border-purple-200",
+    icon: "🎨",
+    placeholderImage: "https://images.unsplash.com/photo-1541961017774-22349e4a1262?w=400&h=400&fit=crop&crop=center",
+  },
+  farcaster: {
+    name: "Farcaster",
+    color: "bg-blue-100 text-blue-700 border-blue-200",
+    icon: "🟣",
+    placeholderImage: "https://images.unsplash.com/photo-1611224923853-80b023f02d71?w=400&h=400&fit=crop&crop=center",
+  },
+  lens: {
+    name: "Lens",
+    color: "bg-green-100 text-green-700 border-green-200",
+    icon: "🌿",
+    placeholderImage: "https://images.unsplash.com/photo-1557804506-669a67965ba0?w=400&h=400&fit=crop&crop=center",
+  },
+  paragraph: {
+    name: "Paragraph",
+    color: "bg-orange-100 text-orange-700 border-orange-200",
+    icon: "📝",
+    placeholderImage: "https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=400&h=400&fit=crop&crop=center",
+  },
+  twitter: {
+    name: "Twitter",
+    color: "bg-sky-100 text-sky-700 border-sky-200",
+    icon: "🐦",
+    placeholderImage: "https://images.unsplash.com/photo-1611605698335-8b1569810432?w=400&h=400&fit=crop&crop=center",
+  },
+  pods: {
+    name: "Pods",
+    color: "bg-indigo-100 text-indigo-700 border-indigo-200",
+    icon: "🎧",
+    placeholderImage: "https://images.unsplash.com/photo-1478737270239-2f02b77fc618?w=400&h=400&fit=crop&crop=center",
+  },
+};
+
+export function FeedGridV2({ posts = [] }: FeedGridV2Props) {
+  // Mock data for demonstration - in real app this would come from API
+  const mockPosts: FeedPostV2[] = [
+    {
+      platform: "zora",
+      title: "Digital Art Collection #1",
+      revenue: "2.5 ETH",
+      collectors: 45,
+      date: "2024-01-15",
+      url: "https://zora.co/collection/123",
+      imageUrl: "https://images.unsplash.com/photo-1541961017774-22349e4a1262?w=400&h=400&fit=crop&crop=center",
+      imageAlt: "Digital art collection",
+    },
+    {
+      platform: "farcaster",
+      content: "Just launched my new creator score app! 🚀",
+      retweets: 23,
+      likes: 156,
+      date: "2024-01-20",
+      url: "https://warpcast.com/~/cast/123",
+      imageUrl: "https://images.unsplash.com/photo-1611224923853-80b023f02d71?w=400&h=400&fit=crop&crop=center",
+      imageAlt: "App launch celebration",
+    },
+    {
+      platform: "lens",
+      content: "Building the future of social media...",
+      retweets: 12,
+      likes: 89,
+      date: "2024-01-18",
+      url: "https://lens.xyz/posts/123",
+      imageUrl: "https://images.unsplash.com/photo-1557804506-669a67965ba0?w=400&h=400&fit=crop&crop=center",
+      imageAlt: "Social media future",
+    },
+    {
+      platform: "paragraph",
+      title: "The Future of Creator Economy",
+      revenue: "0.8 ETH",
+      collectors: 23,
+      date: "2024-01-22",
+      url: "https://paragraph.xyz/article/123",
+      imageUrl: "https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=400&h=400&fit=crop&crop=center",
+      imageAlt: "Creator economy article",
+    },
+    {
+      platform: "twitter",
+      content: "Excited to share my latest project with everyone! 🚀",
+      retweets: 45,
+      likes: 234,
+      date: "2024-01-19",
+      url: "https://twitter.com/user/status/123",
+      imageUrl: "https://images.unsplash.com/photo-1611605698335-8b1569810432?w=400&h=400&fit=crop&crop=center",
+      imageAlt: "Project announcement",
+    },
+    {
+      platform: "pods",
+      title: "Creator Economy Podcast #15",
+      revenue: "1.2 ETH",
+      collectors: 67,
+      date: "2024-01-21",
+      url: "https://pods.xyz/podcast/123",
+      imageUrl: "https://images.unsplash.com/photo-1478737270239-2f02b77fc618?w=400&h=400&fit=crop&crop=center",
+      imageAlt: "Podcast episode",
+    },
+  ];
+
+  const displayPosts = posts.length > 0 ? posts : mockPosts;
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", { 
+      month: "short", 
+      day: "numeric",
+      year: "numeric"
+    });
+  };
+
+  const truncateText = (text: string, maxLength: number = 20) => {
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + "...";
+  };
+
+  const handlePostClick = async (url?: string) => {
+    if (!url) return;
+    
+    try {
+      // Try to open in Farcaster frame if available
+      if (typeof window !== "undefined" && (window as any).farcaster) {
+        await (window as any).farcaster.openUrl(url);
+      } else {
+        window.open(url, "_blank", "noopener,noreferrer");
+      }
+    } catch {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {displayPosts.map((post, index) => {
+        const config = platformConfig[post.platform];
+        const imageUrl = post.imageUrl || config.placeholderImage;
+        
+        return (
+          <Card 
+            key={index} 
+            className={cn(
+              "cursor-pointer transition-all duration-200 hover:shadow-lg",
+              "border border-gray-200 overflow-hidden"
+            )}
+            onClick={() => handlePostClick(post.url)}
+          >
+            {/* Header */}
+            <CardHeader className="pb-3 px-4 pt-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center">
+                    <span className="text-sm">{config.icon}</span>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-sm">{config.name}</h4>
+                    <p className="text-xs text-muted-foreground">{formatDate(post.date)}</p>
+                  </div>
+                </div>
+                {post.url && (
+                  <ExternalLink className="w-4 h-4 text-muted-foreground" />
+                )}
+              </div>
+            </CardHeader>
+
+            {/* Image */}
+            <div className="relative aspect-square bg-gray-100">
+              <img
+                src={imageUrl}
+                alt={post.imageAlt || `${config.name} post`}
+                className="w-full h-full object-cover"
+                onError={(e) => {
+                  const target = e.target as HTMLImageElement;
+                  target.src = config.placeholderImage;
+                }}
+              />
+            </div>
+
+            {/* Content */}
+            <CardContent className="px-4 py-3 space-y-3">
+              {/* Text Content */}
+              <div className="space-y-2">
+                {post.title && (
+                  <h5 className="font-medium text-sm leading-tight">
+                    {post.title}
+                  </h5>
+                )}
+                {post.content && (
+                  <p className="text-sm text-muted-foreground leading-tight">
+                    {post.content}
+                  </p>
+                )}
+              </div>
+
+              {/* Stats */}
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  {post.revenue && (
+                    <div className="flex items-center gap-1 text-xs">
+                      <TrendingUp className="w-3 h-3 text-green-600" />
+                      <span className="font-medium text-green-600">{post.revenue}</span>
+                    </div>
+                  )}
+                  
+                  {post.collectors && (
+                    <div className="flex items-center gap-1 text-xs">
+                      <Users className="w-3 h-3 text-blue-600" />
+                      <span className="text-muted-foreground">{post.collectors}</span>
+                    </div>
+                  )}
+                  
+                  {post.retweets && (
+                    <div className="flex items-center gap-1 text-xs">
+                      <Repeat className="w-3 h-3 text-blue-500" />
+                      <span className="text-muted-foreground">{post.retweets}</span>
+                    </div>
+                  )}
+                  
+                  {post.likes && (
+                    <div className="flex items-center gap-1 text-xs">
+                      <Heart className="w-3 h-3 text-red-500" />
+                      <span className="text-muted-foreground">{post.likes}</span>
+                    </div>
+                  )}
+                </div>
+
+                {/* Platform Badge */}
+                <Badge 
+                  variant="secondary" 
+                  className={cn("text-xs", config.color)}
+                >
+                  {config.name}
+                </Badge>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+} 

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,302 @@
+// Category mapping based on credential issuers
+export const CREDENTIAL_CATEGORIES = {
+  // Artist category
+  "Zora": "Artist",
+  "Base": "Artist", 
+  "Phi": "Artist",
+  
+  // Reply Guy category
+  "Farcaster": "Reply Guy",
+  "Lens": "Reply Guy", 
+  "Twitter": "Reply Guy",
+  "X/Twitter": "Reply Guy",
+  "Noice": "Reply Guy",
+  
+  // Writer category
+  "Mirror": "Writer",
+  "Paragraph": "Writer",
+  
+  // Music category
+  "Coop Records": "Music",
+  
+  // Podcaster category
+  "Pods": "Podcaster",
+  
+  // No category (these won't contribute to categorization)
+  "Onchain activity": null,
+  "EFP": null,
+  "Stack": null,
+  "ENS": null,
+  "Flaunch": null,
+} as const;
+
+// All possible issuers that should be shown in the breakdown
+export const ALL_ISSUERS = [
+  "Zora",
+  "Base", 
+  "Phi",
+  "Farcaster",
+  "Lens", 
+  "Twitter",
+  "X/Twitter",
+  "Noice",
+  "Mirror",
+  "Paragraph",
+  "Coop Records",
+  "Pods",
+  "Flaunch",
+] as const;
+
+export type Category = "Artist" | "Reply Guy" | "Writer" | "Music" | "Podcaster";
+
+export interface CategoryBreakdown {
+  category: Category;
+  points: number;
+  percentage: number;
+  credentials: Array<{
+    issuer: string;
+    label: string;
+    points: number;
+  }>;
+}
+
+export interface CreatorCategory {
+  primaryCategory: Category | null;
+  breakdown: CategoryBreakdown[];
+  issuerBreakdown: Array<{
+    issuer: string;
+    category: Category | null;
+    points: number;
+    percentage: number;
+    credentials: Array<{
+      issuer: string;
+      label: string;
+      points: number;
+    }>;
+  }>;
+  totalPoints: number;
+}
+
+/**
+ * Determines the primary category for a creator based on their credentials
+ */
+export function determineCreatorCategory(
+  issuerGroups: Array<{
+    issuer: string;
+    total: number;
+    points: Array<{
+      label: string;
+      value: number;
+    }>;
+  }>
+): CreatorCategory {
+  const categoryPoints = new Map<Category, number>();
+  const categoryCredentials = new Map<Category, Array<{
+    issuer: string;
+    label: string;
+    points: number;
+  }>>();
+
+  let totalPoints = 0;
+
+  // Calculate points per category
+  issuerGroups.forEach(group => {
+    const category = CREDENTIAL_CATEGORIES[group.issuer as keyof typeof CREDENTIAL_CATEGORIES];
+    
+    if (category) {
+      const currentPoints = categoryPoints.get(category) || 0;
+      categoryPoints.set(category, currentPoints + group.total);
+      
+      const currentCredentials = categoryCredentials.get(category) || [];
+      const newCredentials = group.points.map(point => ({
+        issuer: group.issuer,
+        label: point.label,
+        points: point.value,
+      }));
+      categoryCredentials.set(category, [...currentCredentials, ...newCredentials]);
+    }
+    
+    totalPoints += group.total;
+  });
+
+  // Find primary category (highest points)
+  let primaryCategory: Category | null = null;
+  let maxPoints = 0;
+
+  categoryPoints.forEach((points, category) => {
+    if (points > maxPoints) {
+      maxPoints = points;
+      primaryCategory = category;
+    }
+  });
+
+  // Create breakdown with all categories (including 0 points)
+  const allCategories: Category[] = ["Artist", "Reply Guy", "Writer", "Music", "Podcaster"];
+  const categoryBreakdown: CategoryBreakdown[] = allCategories.map(category => {
+    const points = categoryPoints.get(category) || 0;
+    const credentials = categoryCredentials.get(category) || [];
+    
+    return {
+      category,
+      points,
+      percentage: totalPoints > 0 ? (points / totalPoints) * 100 : 0,
+      credentials,
+    };
+  }).sort((a, b) => b.points - a.points);
+
+  // Create issuer breakdown for the modal
+  const issuerBreakdown: Array<{
+    issuer: string;
+    category: Category | null;
+    points: number;
+    percentage: number;
+    credentials: Array<{
+      issuer: string;
+      label: string;
+      points: number;
+    }>;
+  }> = ALL_ISSUERS.map(issuer => {
+    const category = CREDENTIAL_CATEGORIES[issuer as keyof typeof CREDENTIAL_CATEGORIES];
+    const issuerPoints = issuerGroups.find(g => g.issuer === issuer)?.total || 0;
+    const issuerCredentials = issuerGroups.find(g => g.issuer === issuer)?.points.map(point => ({
+      issuer,
+      label: point.label,
+      points: point.value,
+    })) || [];
+    
+    return {
+      issuer,
+      category,
+      points: issuerPoints,
+      percentage: totalPoints > 0 ? (issuerPoints / totalPoints) * 100 : 0,
+      credentials: issuerCredentials,
+    };
+  }).sort((a, b) => b.points - a.points);
+
+  return {
+    primaryCategory,
+    breakdown: categoryBreakdown,
+    issuerBreakdown,
+    totalPoints,
+  };
+}
+
+/**
+ * Get category color for UI
+ */
+export function getCategoryColor(category: Category): string {
+  switch (category) {
+    case "Artist":
+      return "bg-gradient-to-r from-purple-500 to-pink-500";
+    case "Reply Guy":
+      return "bg-gradient-to-r from-blue-500 to-cyan-500";
+    case "Writer":
+      return "bg-gradient-to-r from-emerald-500 to-teal-500";
+    case "Music":
+      return "bg-gradient-to-r from-rose-500 to-purple-600";
+    case "Podcaster":
+      return "bg-gradient-to-r from-orange-500 to-red-500";
+    default:
+      return "bg-gradient-to-r from-gray-500 to-gray-600";
+  }
+}
+
+/**
+ * Get category color for SVG (without bg- prefix)
+ */
+export function getCategorySvgColor(category: Category): string {
+  switch (category) {
+    case "Artist":
+      return "#a855f7"; // vibrant purple
+    case "Reply Guy":
+      return "#06b6d4"; // vibrant cyan
+    case "Writer":
+      return "#10b981"; // vibrant emerald
+    case "Music":
+      return "#f43f5e"; // vibrant rose
+    case "Podcaster":
+      return "#f97316"; // vibrant orange
+    default:
+      return "#6b7280"; // gray-500
+  }
+}
+
+/**
+ * Get category background color for cards
+ */
+export function getCategoryBgColor(category: Category): string {
+  switch (category) {
+    case "Artist":
+      return "bg-purple-50 border-purple-200";
+    case "Reply Guy":
+      return "bg-cyan-50 border-cyan-200";
+    case "Writer":
+      return "bg-emerald-50 border-emerald-200";
+    case "Music":
+      return "bg-rose-50 border-rose-200";
+    case "Podcaster":
+      return "bg-orange-50 border-orange-200";
+    default:
+      return "bg-gray-50 border-gray-200";
+  }
+}
+
+/**
+ * Get category pastel color for progress bars
+ */
+export function getCategoryPastelColor(category: Category): string {
+  switch (category) {
+    case "Artist":
+      return "#f3e8ff"; // purple-100
+    case "Reply Guy":
+      return "#cffafe"; // cyan-100
+    case "Writer":
+      return "#d1fae5"; // emerald-100
+    case "Music":
+      return "#ffe4e6"; // rose-100
+    case "Podcaster":
+      return "#fed7aa"; // orange-100
+    default:
+      return "#f3f4f6"; // gray-100
+  }
+}
+
+/**
+ * Get category pastel progress color for progress bars
+ */
+export function getCategoryPastelProgressColor(category: Category): string {
+  switch (category) {
+    case "Artist":
+      return "#c084fc"; // purple-400
+    case "Reply Guy":
+      return "#22d3ee"; // cyan-400
+    case "Writer":
+      return "#34d399"; // emerald-400
+    case "Music":
+      return "#fb7185"; // rose-400
+    case "Podcaster":
+      return "#fb923c"; // orange-400
+    default:
+      return "#9ca3af"; // gray-400
+  }
+}
+
+/**
+ * Get category icon for UI
+ */
+export function getCategoryIcon(category: Category): string {
+  switch (category) {
+    case "Artist":
+      return "🎨";
+    case "Reply Guy":
+      return "💬";
+    case "Writer":
+      return "✍️";
+    case "Music":
+      return "🎵";
+    case "Podcaster":
+      return "🎙️";
+    default:
+      return "👤";
+  }
+} 


### PR DESCRIPTION
- Add FeedGrid component with 2x2 grid layout showing posts from 6 platforms
- Add FeedGridV2 component with Instagram-style vertical feed layout
- Support for Zora, Farcaster, Lens, Paragraph, Twitter, and Pods
- Platform-specific data display (revenue, collectors, retweets, likes)
- Placeholder images for each platform using Unsplash
- Interactive cards that open original posts
- Add CategoryBreakdownModal component for detailed score breakdown
- Add categories.ts utility for creator category classification