### PR TITLE
Fix Privy modal search/scroll conflicts

### DIFF
--- a/components/modals/FarcasterAccessModal.tsx
+++ b/components/modals/FarcasterAccessModal.tsx
@@ -116,7 +116,10 @@ export function FarcasterAccessModal({
             </Button>
 
             <Button
-              onClick={() => login({ walletChainType: "ethereum-only" })}
+              onClick={() => {
+                onOpenChange(false);
+                login({ walletChainType: "ethereum-only" });
+              }}
               className="w-full"
               disabled={!ready}
             >
@@ -153,7 +156,10 @@ export function FarcasterAccessModal({
               Open in Farcaster
             </Button>
             <Button
-              onClick={() => login({ walletChainType: "ethereum-only" })}
+              onClick={() => {
+                onOpenChange(false);
+                login({ walletChainType: "ethereum-only" });
+              }}
               className="w-full"
               disabled={!ready}
             >

--- a/hooks/useLeaderboardOptimized.ts
+++ b/hooks/useLeaderboardOptimized.ts
@@ -33,23 +33,15 @@ export function useLeaderboardData(): UseLeaderboardOptimizedReturn {
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [nextUpdate, setNextUpdate] = useState<string | null>(null);
 
-  // Filter out entries with $0 rewards or rank > 200
+  // Filter out entries with rank > 200 only
   const filterValidEntries = useCallback(
     (rawEntries: LeaderboardEntry[]): LeaderboardEntry[] => {
       return rawEntries.filter((entry) => {
         // Skip entries with rank > 200
         if (!entry.rank || entry.rank > 200) return false;
 
-        // Skip entries with $0 rewards
-        const reward = RewardsCalculationService.calculateUserReward(
-          entry.score,
-          entry.rank,
-          entry.isBoosted || false,
-          entry.isOptedOut || false,
-          rawEntries,
-        );
-
-        return reward !== "$0";
+        // Don't filter out opted-out users - they should show their donated amount
+        return true;
       });
     },
     [],
@@ -67,7 +59,7 @@ export function useLeaderboardData(): UseLeaderboardOptimizedReturn {
     }>(cacheKey, CACHE_DURATIONS.LEADERBOARD_DATA);
 
     if (cachedData) {
-      // Filter out entries with $0 rewards or rank > 200
+      // Filter out entries with rank > 200 only
       const filteredEntries = filterValidEntries(cachedData.entries);
 
       setEntries(filteredEntries);
@@ -95,7 +87,7 @@ export function useLeaderboardData(): UseLeaderboardOptimizedReturn {
 
       const data = await response.json();
 
-      // Filter out entries with $0 rewards or rank > 200
+      // Filter out entries with rank > 200 only
       const filteredEntries = filterValidEntries(data.entries);
 
       setEntries(filteredEntries);


### PR DESCRIPTION
## Overview
This PR contains two critical fixes that address modal conflicts and leaderboard display issues.

## 🔧 Bug Fixes

### 1. Privy Modal Search/Scroll Conflicts
**Problem**: When users try to access private pages without authentication, the FarcasterAccessModal appears first. When they click 'Login with Privy', a second modal from Privy opens on top. However, when users click 'Other wallets' in the Privy modal, both the search functionality and scrolling become unresponsive.

**Root Cause**: The issue is caused by z-index and pointer-events conflicts between the two modals:
- FarcasterAccessModal uses z-50
- Privy modal also uses z-50  
- Both modals exist simultaneously, causing pointer events to be intercepted
- The underlying FarcasterAccessModal blocks interactions with Privy's modal content

**Solution**: Close the FarcasterAccessModal immediately when the Privy login is triggered, before Privy's modal opens. This ensures:
- Only one modal exists at a time (no z-index conflicts)
- Pointer events aren't intercepted by overlapping modal overlays
- Privy modal can function properly with search and scroll functionality

**Changes**: Modified onClick handlers for 'Login with Privy' buttons to call `onOpenChange(false)` first, then trigger the Privy login.

### 2. Leaderboard Opted-Out Users Missing
**Problem**: Opted-out users were disappearing from the leaderboard due to overly aggressive filtering logic that was hiding users with $0 rewards.

**Root Cause**: The `filterValidEntries` function was filtering out users based on calculated rewards, which excluded opted-out users who had donated amounts but showed $0 in rewards.

**Solution**: Remove the overly aggressive filtering that was hiding opted-out users. Now:
- Only filter out users with rank > 200
- Don't filter out opted-out users - they should show their donated amount with green strikethrough
- Maintain leaderboard integrity for all top 200 creators

**Changes**: 
- Removed reward-based filtering logic from `filterValidEntries`
- Updated function to only filter by rank > 200
- Opted-out users now appear in leaderboard with their rank and percentile
- They show their donated amount (e.g., "$45") with green strikethrough styling
- No more "0 points left to earn rewards" for opted-out users

## 📋 Files Changed

**Components:**
- `components/modals/FarcasterAccessModal.tsx` - Fix Privy modal conflicts

**Hooks:**
- `hooks/useLeaderboardOptimized.ts` - Restore opted-out users in leaderboard

## 🧪 Testing

- [x] Verified the Privy modal fix resolves search functionality issues
- [x] Verified the Privy modal fix resolves scrolling issues  
- [x] Confirmed opted-out users now appear in leaderboard
- [x] Verified opted-out users show their donated amounts correctly
- [x] Confirmed minimal code changes maintain existing functionality

## 🎯 Impact

This PR significantly improves the user experience by:
- **Fixing critical authentication flow** issues with Privy modal conflicts
- **Restoring leaderboard visibility** for opted-out users
- **Maintaining data integrity** across all user types
- **Providing consistent UI** for both authentication and leaderboard display

All changes maintain backward compatibility and follow established architectural patterns.
