### PR TITLE
Fix: Snapshot service stores actual earned amounts for all users

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -397,7 +397,7 @@ function LeaderboardContent() {
             value={`$${formatCompactNumber(TOTAL_SPONSORS_POOL)}`}
           />
           <StatCard
-            title="TOP200 Snapshot"
+            title="TOP200 Snapshot in..."
             value={`${countdown.days}d ${countdown.hours}h`}
           />
         </div>

--- a/app/services/leaderboardSnapshotService.ts
+++ b/app/services/leaderboardSnapshotService.ts
@@ -42,13 +42,13 @@ export class LeaderboardSnapshotService {
       // Transform leaderboard entries to snapshot format with calculated rewards
       const snapshots = await Promise.all(
         entries.map(async (entry) => {
-          const rewardAmount = RewardsCalculationService.calculateUserReward(
-            entry.score,
-            entry.rank,
-            entry.isBoosted || false,
-            entry.isOptedOut || false,
-            entries,
-          );
+          const rewardAmount =
+            RewardsCalculationService.calculatePureUserReward(
+              entry.score,
+              entry.rank,
+              entry.isBoosted || false,
+              entries,
+            );
 
           // Extract numeric value from formatted string (e.g., "$138" -> 138)
           const numericAmount =


### PR DESCRIPTION
## Problem
The snapshot service was storing $0 for opted-out users instead of their actual earned amounts. This meant the snapshot didn't reflect what users actually earned based on their creator score and boost.

## Solution
- Added  method that ignores opt-out status
- Updated snapshot creation to use pure reward calculation
- Snapshot now stores what users actually earned regardless of opt-in/opt-out decision

## Key Benefits
- **Separation of Concerns**: Snapshot = earnings, User Preferences = decisions
- **Data Integrity**: Snapshot becomes a true historical record of earnings
- **Auditability**: Clear distinction between earnings and decisions
- **Flexibility**: Opt-in/opt-out logic can change without affecting snapshot

## Testing
- ✅ Build successful with no TypeScript errors
- ✅ Method correctly calculates rewards for all users
- ✅ Verified that users with $0 in snapshot actually earned significant amounts

## Files Changed
-  - Added  method
-  - Updated to use pure reward calculation

This ensures all top 200 users will have their actual earned amounts stored in the snapshot, providing a clean historical record for the rewards distribution process.